### PR TITLE
add fifth step - get elected color

### DIFF
--- a/contracts/color-vote.clar
+++ b/contracts/color-vote.clar
@@ -20,5 +20,30 @@
 
 (define-read-only (get-nb-of-voters) (var-get nb-of-voters))
 
+(define-read-only (get-color (id uint))
+  (ok {
+    id: id,
+    value: (unwrap! (element-at COLORS id) ERR_NOT_FOUND),
+    score: (unwrap! (element-at (var-get scores) id) ERR_NOT_FOUND),
+  })
+)
+
+(define-read-only (get-colors) (map get-color (list u0 u1 u2 u3)))
+
+(define-private (find-best
+  (next uint)
+  (current (optional { id: uint, score: uint }))
+)
+  (let ((next-score (unwrap-panic (element-at (var-get scores) next))))
+    (if (> next-score (default-to u0 (get score current)))
+      (some { id: next, score: next-score })
+      current
+    )
+  )
+)
+
+(define-read-only (get-elected) (fold find-best (list u0 u1 u2 u3) none))
+
 (define-constant ERR_BAD_REQUEST (err u400))
+(define-constant ERR_NOT_FOUND (err u404))
 (define-constant ERR_FORBIDDEN (err u403))

--- a/tests/color-vote_test.ts
+++ b/tests/color-vote_test.ts
@@ -8,6 +8,17 @@ import {
 
 const { uint } = types
 
+type CVColor = {
+  id: string
+  score: string
+  value: string
+}
+
+type CVElected = {
+  id: string
+  score: string
+}
+
 Clarinet.test({
   name: '`get-nb-of-voters` - returns the right number of voters',
   fn(chain: Chain, accounts: Map<string, Account>) {
@@ -17,6 +28,53 @@ Clarinet.test({
     ])
 
     receipts[0].result.expectUint(0)
+  },
+})
+
+Clarinet.test({
+  name: '`get-color` - returns the right color',
+  fn(chain: Chain, accounts: Map<string, Account>) {
+    const { address } = accounts.get('wallet_1')!
+    const { receipts } = chain.mineBlock([
+      Tx.contractCall('color-vote', 'get-color', [uint(1)], address),
+    ])
+
+    // `as CVColor` is not the cleanest way to do it but it's good enough
+    const color = receipts[0].result.expectOk().expectTuple() as CVColor
+    color.id.expectUint(1)
+    color.score.expectUint(0)
+    color.value.expectAscii('D1C0A8')
+  },
+})
+
+Clarinet.test({
+  name: '`get-color` - returns 404 for invalid id',
+  fn(chain: Chain, accounts: Map<string, Account>) {
+    const { address } = accounts.get('wallet_1')!
+    const { receipts } = chain.mineBlock([
+      Tx.contractCall('color-vote', 'get-color', [uint(10)], address),
+    ])
+
+    receipts[0].result.expectErr().expectUint(404)
+  },
+})
+
+Clarinet.test({
+  name: '`get-colors` - returns the array of colors',
+  fn(chain: Chain, accounts: Map<string, Account>) {
+    const { address } = accounts.get('wallet_1')!
+    const { receipts } = chain.mineBlock([
+      Tx.contractCall('color-vote', 'get-colors', [], address),
+    ])
+
+    const colors = receipts[0].result.expectList()
+
+    const expectedColors = ['F97316', 'D1C0A8', '2563EB', '65A30D']
+    colors.forEach((colorTuple, i) => {
+      const color = colorTuple.expectOk().expectTuple() as CVColor
+      color.id.expectUint(i)
+      color.value.expectAscii(expectedColors[i])
+    })
   },
 })
 
@@ -49,6 +107,21 @@ Clarinet.test({
 })
 
 Clarinet.test({
+  name: '`vote` - sets the vote values',
+  fn(chain: Chain, accounts: Map<string, Account>) {
+    const { address } = accounts.get('wallet_1')!
+    const { receipts } = chain.mineBlock([
+      Tx.contractCall('color-vote', 'vote', [5, 4, 3, 2].map(uint), address),
+      Tx.contractCall('color-vote', 'get-color', [uint(0)], address),
+    ])
+
+    receipts[0].result.expectOk()
+    const color = receipts[1].result.expectOk().expectTuple() as CVColor
+    color.score.expectUint(5)
+  },
+})
+
+Clarinet.test({
   name: '`vote` - throw an error if the vote is not valid',
   fn(chain: Chain, accounts: Map<string, Account>) {
     const { address } = accounts.get('wallet_1')!
@@ -57,5 +130,22 @@ Clarinet.test({
     ])
 
     receipts[0].result.expectErr().expectUint(400)
+  },
+})
+
+Clarinet.test({
+  name: '`get-elected` - returns elected',
+  fn(chain: Chain, accounts: Map<string, Account>) {
+    const { address } = accounts.get('wallet_1')!
+    const { receipts } = chain.mineBlock([
+      Tx.contractCall('color-vote', 'vote', [0, 4, 0, 0].map(uint), address),
+      Tx.contractCall('color-vote', 'get-elected', [], address),
+    ])
+
+    receipts[0].result.expectOk().expectBool(true)
+
+    const elected = receipts[1].result.expectSome().expectTuple() as CVElected
+    elected.id.expectUint(1)
+    elected.score.expectUint(4)
   },
 })


### PR DESCRIPTION
[Article](https://www.clearness.dev/01-voting-clarity-smart-contract/05-get-elected-color)